### PR TITLE
Contributor picture fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target
 *~
 .idea
+*.iml

--- a/src/main/java/com/cobalt/bamboo/plugin/pipeline/domain/model/ContributorBuilder.java
+++ b/src/main/java/com/cobalt/bamboo/plugin/pipeline/domain/model/ContributorBuilder.java
@@ -51,7 +51,7 @@ public class ContributorBuilder {
             String profilePageUrl = jiraBaseUrl + JIRA_PROFILE_PATH + username;
             return new Contributor(username, lastCommitDate, fullName, pictureUrl, profilePageUrl);
         } else {
-            return new Contributor(username, lastCommitDate, fullName, null, null);
+            return new Contributor(username, lastCommitDate, fullName, "http://lorempixel.com/32/32/cats/", null);
         }
     }
 }


### PR DESCRIPTION
- If there's no JIRA applink setup, then show a random cat picture for contributors instead of the empty image.

- Updating gitignore with intellij files