### PR TITLE
Error: "Current build completed time shouldn't be before first build completed time."

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <bamboo.version>5.7.0</bamboo.version>
         <bamboo.data.version>5.7.0</bamboo.data.version>
-        <amps.version>5.0.13</amps.version>
+        <amps.version>6.2.1</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
     </properties>
     <dependencies>

--- a/src/main/java/com/cobalt/bamboo/plugin/pipeline/domain/model/UptimeGrade.java
+++ b/src/main/java/com/cobalt/bamboo/plugin/pipeline/domain/model/UptimeGrade.java
@@ -20,15 +20,20 @@ public class UptimeGrade {
 	 * @param currentBuildDate of the most recent completed build
 	 */
 	public UptimeGrade(Date startDate, long totalUptime, boolean currentBuildSuccess, Date currentBuildDate){
-		if(startDate != null && currentBuildDate != null && startDate.compareTo(currentBuildDate) > 0) {
-			throw new IllegalArgumentException("Current build completed time shouldn't be before first build completed time.");
-		}
 		if(startDate != null){
 			this.startDate = new Date(startDate.getTime());
 		}
 		if(currentBuildDate != null){
 			this.currentBuildDate = new Date(currentBuildDate.getTime());
 		}
+		/**
+		 * This shouldn't happen, but it has, and so we'll just do our best (since we can't change the data)
+		 * and end up with a build that took no time (but at least can be graded on failure/success).
+		 */
+		if (startDate != null && currentBuildDate != null && startDate.compareTo(currentBuildDate) > 0) {
+			this.startDate = currentBuildDate;
+		}
+
 		this.totalUptime = totalUptime;
 		this.currentBuildSuccess = currentBuildSuccess;
 	}

--- a/src/test/java/com/cobalt/bamboo/plugin/pipeline/domain/model/UptimeGradeTest.java
+++ b/src/test/java/com/cobalt/bamboo/plugin/pipeline/domain/model/UptimeGradeTest.java
@@ -25,11 +25,6 @@ public class UptimeGradeTest {
 		assertEquals("Grade is not as expected.", null, g.getGrade());
 	}
 
-	@Test(expected=IllegalArgumentException.class)
-	public void testCurrentDateBeforeStartDate() {
-		UptimeGrade g = new UptimeGrade(new Date(), 0, false, new Date((new Date()).getTime() - 1000000));
-	}
-	
 	@Test
 	public void testStartDateEqualsCurrentBuildDateSuccess() {
 		Date current = new Date();


### PR DESCRIPTION
A bug was reported that appeared to be due to a build where the compl…etion time was at or before the start time, failing one of the checks. I've removed the check and instead tried to just set the start and end dates to the same (so a build with no length, but at least it won't kill the plugin)